### PR TITLE
Fixed visualisation of tags in debug and error mode

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -149,9 +149,9 @@ func Printf(format string, args ...interface{}) {
 }
 
 func Debugf(format string, args ...interface{}) {
-	Default.printf("dbg "+format, 4, args...)
+	Default.printf("dbg"+format, 4, args...)
 }
 
 func Errorf(format string, args ...interface{}) {
-	Default.printf("err "+format, 4, args...)
+	Default.printf("err"+format, 4, args...)
 }


### PR DESCRIPTION
The issue was that tags were not printed correctly in error and debug cases.
Now if the tag didn't contain spaces everything works fine and all tags are shown correctly.