### PR TITLE
Make possible to use err as a part of text, not only as a tag

### DIFF
--- a/message.go
+++ b/message.go
@@ -21,7 +21,7 @@ func NewMessage(format string, args ...any) Message {
 		createdAt: time.Now(),
 	}
 	for _, n := range []string{"dbg", "err", "inf"} {
-		if p := strings.Index(m.text, n); p != -1 {
+		if p := strings.Index(m.text, n); p != -1 && (p == 0 || m.text[p-1] == ':') {
 			m.text, m.typ = strings.Replace(m.text, n, "", 1), strings.ToTitle(n)
 			break
 		}

--- a/message.go
+++ b/message.go
@@ -15,12 +15,14 @@ type Message struct {
 	createdAt time.Time
 }
 
+var types = []string{"dbg", "err", "inf"}
+
 func NewMessage(format string, args ...any) Message {
 	m := Message{
 		text:      fmt.Sprintf(format, args...),
 		createdAt: time.Now(),
 	}
-	for _, n := range []string{"dbg", "err", "inf"} {
+	for _, n := range types {
 		if p := strings.Index(m.text, n); p != -1 && (p == 0 || m.text[p-1] == ':') {
 			m.text, m.typ = strings.Replace(m.text, n, "", 1), strings.ToTitle(n)
 			break

--- a/message_test.go
+++ b/message_test.go
@@ -31,6 +31,7 @@ func TestMessage_Render(t *testing.T) {
 		{"multiple tags and text", "payments:billing: Tim balance updated", nil, "[INF] [payments:billing] Tim balance updated"},
 		{"tag and dbg type with text", "payments:dbg hi again", nil, "[DBG] [payments] hi again"},
 		{"tag with spaces are ignored", "something tricky:err is here", nil, "[ERR] something tricky: is here"},
+		{"text with tag and err message in it", "foo: info with no err type", nil, "[INF] [foo] info with no err type"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Fixed bug to make possible to use INFO tag in case no tag provided and "err" word used as a part of a text message